### PR TITLE
Workaround for running on default GPU if ID not specified

### DIFF
--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -134,9 +134,13 @@ int train() {
   // If the gpus flag is not provided, allow the mode and device to be set
   // in the solver prototxt.
   if (FLAGS_gpu.size() == 0
-      && solver_param.solver_mode() == caffe::SolverParameter_SolverMode_GPU
-      && solver_param.has_device_id()) {
-    FLAGS_gpu = "" + boost::lexical_cast<string>(solver_param.device_id());
+      && solver_param.solver_mode() == caffe::SolverParameter_SolverMode_GPU) {
+      if (solver_param.has_device_id()) {
+          FLAGS_gpu = ""  +
+              boost::lexical_cast<string>(solver_param.device_id());
+      } else {  // Set default GPU if unspecified
+          FLAGS_gpu = "" + boost::lexical_cast<string>(0);
+      }
   }
 
   vector<int> gpus;


### PR DESCRIPTION
This is a workaround to restore older behavior if the user specifies the solver to run on the GPU but neglects to select a device.  This will setup the default device, device 0, as the device to use.
